### PR TITLE
Use docker instead of docker-py

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 install:
   - pip install -U pip
   - pip --version
-  - pip install ansible ansible-lint yamllint flake8 molecule docker-py
+  - pip install ansible ansible-lint yamllint flake8 molecule docker
   - ansible-lint --version
   - yamllint --version
   - flake8 --version


### PR DESCRIPTION
docker-py is an outdated version of the docker library on pypi, and has compatibility issues with ansible 2.6.